### PR TITLE
Mocsフォルダと.gitignore追加

### DIFF
--- a/Mocs/.gitignore
+++ b/Mocs/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.DS_Store 
+*.swp


### PR DESCRIPTION
LaravelPJ配下にMocページを置くためのMocsフォルダと、
エディターの設定ファイルやらMacが出すファイルを記載した.gitignoreファイルを追加